### PR TITLE
[GMLP-9012] Don't fetch broker tasks into a recycling worker slot

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -17,7 +17,7 @@ from . import local
 
 SERIES = 'immunity'
 
-__version__ = '5.5.3+gumloop_0.1.4'
+__version__ = '5.5.3+gumloop_0.1.5'
 __author__ = 'Rahul Behal'
 __contact__ = 'rahul@gumloop.com'
 __homepage__ = 'https://github.com/gumloop/gumloop-celery'

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -59,6 +59,10 @@ class Tasks(bootsteps.StartStopStep):
                 limit = getattr(c.controller, "max_concurrency", None)
                 if limit is None:
                     limit = c.pool.num_processes
+                # Don't fetch into a recycling slot: count only ready workers.
+                ready = getattr(getattr(c.pool, "_pool", None), "_fileno_to_inq", None)
+                if ready is not None:
+                    limit = min(limit, len(ready))
                 if len(state.reserved_requests) >= limit:
                     return False
                 return original_can_consume()

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -26,6 +26,26 @@ class Tasks(bootsteps.StartStopStep):
         c.task_consumer = c.qos = None
         super().__init__(c, **kwargs)
 
+    @staticmethod
+    def ready_worker_limit(consumer):
+        """Configured concurrency, capped by the number of workers ready to run.
+
+        Excludes children that are recycling/cold-starting (not yet in the
+        pool's ``_fileno_to_inq``) so we don't fetch a task into a slot that
+        can't run it. Guarded: any error, or a pool without that attribute,
+        falls back to the configured concurrency, keeping this purely additive.
+        """
+        limit = getattr(consumer.controller, "max_concurrency", None)
+        if limit is None:
+            limit = consumer.pool.num_processes
+        try:
+            ready = getattr(getattr(consumer.pool, "_pool", None), "_fileno_to_inq", None)
+            if ready is not None:
+                limit = min(limit, len(ready))
+        except Exception:
+            pass
+        return limit
+
     def start(self, c):
         """Start task consumer."""
         c.update_strategies()
@@ -56,14 +76,7 @@ class Tasks(bootsteps.StartStopStep):
             original_can_consume = channel_qos.can_consume
 
             def can_consume(self):
-                limit = getattr(c.controller, "max_concurrency", None)
-                if limit is None:
-                    limit = c.pool.num_processes
-                # Don't fetch into a recycling slot: count only ready workers.
-                ready = getattr(getattr(c.pool, "_pool", None), "_fileno_to_inq", None)
-                if ready is not None:
-                    limit = min(limit, len(ready))
-                if len(state.reserved_requests) >= limit:
+                if len(state.reserved_requests) >= Tasks.ready_worker_limit(c):
                     return False
                 return original_can_consume()
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -706,6 +706,37 @@ class test_Tasks:
         assert record.levelname == "INFO"
         assert record.msg == "Global QoS is disabled. Prefetch count in now static."
 
+    def test_ready_worker_limit_caps_at_ready_workers(self):
+        # Concurrency 3 but only 2 workers have completed the WORKER_UP
+        # handshake (one recycling), so the limit is capped at 2.
+        c = self.c
+        c.controller.max_concurrency = 3
+        c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2'}
+        assert Tasks.ready_worker_limit(c) == 2
+
+    def test_ready_worker_limit_full_when_all_ready(self):
+        c = self.c
+        c.controller.max_concurrency = 3
+        c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2', 12: 'w3'}
+        assert Tasks.ready_worker_limit(c) == 3
+
+    def test_ready_worker_limit_without_prefork_pool(self):
+        # Pools without _fileno_to_inq (solo/eventlet/gevent) keep the prior
+        # behaviour: the configured concurrency.
+        c = self.c
+        c.controller.max_concurrency = None
+        c.pool.num_processes = 3
+        c.pool._pool = object()
+        assert Tasks.ready_worker_limit(c) == 3
+
+    def test_ready_worker_limit_falls_back_on_introspection_error(self):
+        # If reading the ready set raises, fall back to configured concurrency
+        # rather than breaking can_consume (purely additive).
+        c = self.c
+        c.controller.max_concurrency = 3
+        c.pool._pool._fileno_to_inq = object()  # len() raises
+        assert Tasks.ready_worker_limit(c) == 3
+
     def _start_disable_prefetch(self, c):
         c.app.conf.worker_disable_prefetch = True
         c.app.conf.worker_detect_quorum_queues = False
@@ -713,34 +744,12 @@ class test_Tasks:
         return c.task_consumer.channel.qos.can_consume
 
     def test_disable_prefetch_does_not_fetch_into_recycling_slot(self):
-        # Concurrency is 3 but a child is recycling, so only 2 workers have
-        # completed the WORKER_UP handshake. With 2 tasks already reserved we
-        # must not fetch a third into the cold-starting slot.
+        # can_consume gates on ready_worker_limit: 2 ready, 2 reserved -> refuse.
         c = self.c
         c.controller.max_concurrency = 3
         c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2'}
         can_consume = self._start_disable_prefetch(c)
         with patch('celery.worker.state.reserved_requests', [0, 1]):
-            assert can_consume() is False
-
-    def test_disable_prefetch_fetches_when_all_workers_ready(self):
-        c = self.c
-        c.controller.max_concurrency = 3
-        c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2', 12: 'w3'}
-        c.app.amqp.TaskConsumer.return_value.channel.qos.can_consume.return_value = True
-        can_consume = self._start_disable_prefetch(c)
-        with patch('celery.worker.state.reserved_requests', [0, 1]):
-            assert can_consume() is True
-
-    def test_disable_prefetch_falls_back_without_prefork_pool(self):
-        # Pools without _fileno_to_inq (solo/eventlet/gevent) keep the prior
-        # behaviour: gate on the configured concurrency.
-        c = self.c
-        c.controller.max_concurrency = None
-        c.pool.num_processes = 3
-        c.pool._pool = object()
-        can_consume = self._start_disable_prefetch(c)
-        with patch('celery.worker.state.reserved_requests', [0, 1, 2]):
             assert can_consume() is False
 
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -706,6 +706,43 @@ class test_Tasks:
         assert record.levelname == "INFO"
         assert record.msg == "Global QoS is disabled. Prefetch count in now static."
 
+    def _start_disable_prefetch(self, c):
+        c.app.conf.worker_disable_prefetch = True
+        c.app.conf.worker_detect_quorum_queues = False
+        Tasks(c).start(c)
+        return c.task_consumer.channel.qos.can_consume
+
+    def test_disable_prefetch_does_not_fetch_into_recycling_slot(self):
+        # Concurrency is 3 but a child is recycling, so only 2 workers have
+        # completed the WORKER_UP handshake. With 2 tasks already reserved we
+        # must not fetch a third into the cold-starting slot.
+        c = self.c
+        c.controller.max_concurrency = 3
+        c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2'}
+        can_consume = self._start_disable_prefetch(c)
+        with patch('celery.worker.state.reserved_requests', [0, 1]):
+            assert can_consume() is False
+
+    def test_disable_prefetch_fetches_when_all_workers_ready(self):
+        c = self.c
+        c.controller.max_concurrency = 3
+        c.pool._pool._fileno_to_inq = {10: 'w1', 11: 'w2', 12: 'w3'}
+        c.app.amqp.TaskConsumer.return_value.channel.qos.can_consume.return_value = True
+        can_consume = self._start_disable_prefetch(c)
+        with patch('celery.worker.state.reserved_requests', [0, 1]):
+            assert can_consume() is True
+
+    def test_disable_prefetch_falls_back_without_prefork_pool(self):
+        # Pools without _fileno_to_inq (solo/eventlet/gevent) keep the prior
+        # behaviour: gate on the configured concurrency.
+        c = self.c
+        c.controller.max_concurrency = None
+        c.pool.num_processes = 3
+        c.pool._pool = object()
+        can_consume = self._start_disable_prefetch(c)
+        with patch('celery.worker.state.reserved_requests', [0, 1, 2]):
+            assert can_consume() is False
+
 
 class test_Agent:
 


### PR DESCRIPTION
## Problem

With `--disable-prefetch`, `can_consume` (`celery/worker/consumer/tasks.py`) only fetches a broker message when `len(reserved_requests) < pool.num_processes`. `num_processes` is the *static* configured concurrency. When a `--pool=spawn` child is recycled (`worker_max_tasks_per_child` / `worker_max_memory_per_child`), that count still treats the exited child's slot as available, so the worker pulls a task into a slot whose replacement is still cold-starting (re-importing the app, ~10–15s observed in prod) instead of leaving it in the broker for an already-warm worker. Result: high time-to-step-start for the first task a recycled slot picks up.

## Fix

Gate `can_consume` on the number of workers that have completed the `WORKER_UP` handshake — `len(_fileno_to_inq)` — instead of the static `num_processes`. That count drops when a child exits for any reason (incl. OOM SIGKILL, via the sentinel → `maintain_pool` → `on_process_down` path) and recovers once the replacement is live, so the worker stops fetching during a recycle and resumes automatically when the new child is ready. The kombu Redis transport re-checks `can_consume()` every hub tick, so no explicit re-trigger is needed. Falls back to `num_processes` for non-prefork pools (no `_fileno_to_inq`).

`_fileno_to_inq` is the pool's own registry of workers it can dispatch to, so gating consumption on it is consistent with how the pool routes work.

## Tests

Adds `test_disable_prefetch_*` to `t/unit/worker/test_consumer.py` (recycle in progress → refuses; all ready → consumes; non-prefork pool → falls back to `num_processes`).

Bumps version to `5.5.3+gumloop_0.1.5`.

GMLP-9012: https://linear.app/gumloop/issue/GMLP-9012