### PR TITLE
[GMLP-9206] Backport redis-py PR #3557 recursion fix

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -15,6 +15,10 @@ from collections import namedtuple
 # Lazy loading
 from . import local
 
+# Apply redis-py recursion workaround (GMLP-9206) before any kombu/redis-py
+# Connection is instantiated. No-op for redis-py >= 6.0.0b2.
+from . import _redis_py_recursion_workaround  # noqa: F401
+
 SERIES = 'immunity'
 
 __version__ = '5.5.3+gumloop_0.1.5'

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -15,8 +15,6 @@ from collections import namedtuple
 # Lazy loading
 from . import local
 
-# Apply redis-py recursion workaround (GMLP-9206) before any kombu/redis-py
-# Connection is instantiated. No-op for redis-py >= 6.0.0b2.
 from . import _redis_py_recursion_workaround  # noqa: F401
 
 SERIES = 'immunity'

--- a/celery/_redis_py_recursion_workaround.py
+++ b/celery/_redis_py_recursion_workaround.py
@@ -96,7 +96,8 @@ def _apply_redis_py_recursion_workaround() -> None:
     def on_connect_check_health(self, check_health: bool = True) -> None:
         """Initialize the connection, authenticate and select a database.
 
-        Verbatim copy of redis-py 5.2.1's ``Connection.on_connect``,
+        Verbatim copy of redis-py 5.2.1's ``AbstractConnection.on_connect``
+        (https://github.com/redis/redis-py/blob/v5.2.1/redis/connection.py#L398-L487),
         modified to thread ``check_health`` through every ``send_command``
         call so the inner reconnect path can suppress ``check_health`` and
         break the recursion.
@@ -192,8 +193,9 @@ def _apply_redis_py_recursion_workaround() -> None:
     def connect_check_health(self, check_health: bool = True) -> None:
         """Connect to the Redis server if not already connected.
 
-        Verbatim copy of redis-py 5.2.1's ``Connection.connect``, modified
-        to call ``on_connect_check_health(check_health=check_health)``
+        Verbatim copy of redis-py 5.2.1's ``AbstractConnection.connect``
+        (https://github.com/redis/redis-py/blob/v5.2.1/redis/connection.py#L352-L387),
+        modified to call ``on_connect_check_health(check_health=check_health)``
         instead of ``on_connect()``.
         """
         if self._sock:

--- a/celery/_redis_py_recursion_workaround.py
+++ b/celery/_redis_py_recursion_workaround.py
@@ -1,0 +1,89 @@
+"""Backport of redis-py PR #3557 for redis-py < 6.0.0b2.
+
+When the broker connection drops mid-handshake (e.g. broker pod restart,
+TCP RST), redis-py < 6.0.0b2 enters infinite recursion through:
+
+    on_connect() -> send_command("CLIENT","SETINFO",...)
+      -> send_packed_command(check_health=True)
+        -> check_health() -> _send_ping()
+          -> send_command("PING", check_health=False)
+            -> send_packed_command(check_health=False)
+              -> if not self._sock: self.connect()
+                -> on_connect() ...  (RecursionError at ~1000 frames)
+
+The fix in redis-py PR #3557 (released in v6.0.0b2, April 2025) splits
+``connect`` and ``on_connect`` into ``connect_check_health`` /
+``on_connect_check_health`` and threads ``check_health=False`` through
+the inner reconnect path so the cycle cannot form.
+
+Because kombu < 5.6.0 pins ``redis<=5.2.1``, gumloop-celery users cannot
+adopt the fix without a coordinated celery + kombu + redis-py upgrade.
+Until that upgrade lands, this module applies the minimal localized
+patch needed to break the recursion at the call site.
+
+The patch:
+
+- replaces ``Connection.send_packed_command``'s "no socket -> connect()"
+  branch with a clean ``ConnectionError``. Higher-level callers
+  (kombu's Channel, redis.client.Redis, application pools) already
+  handle ``ConnectionError`` with their own retry/reconnect logic, so
+  this surfaces the failure cleanly instead of recursing.
+
+The patch is a no-op when redis-py is unavailable or when it already
+contains the upstream fix (detected by ``connect_check_health`` method).
+
+This module is imported from ``celery/__init__.py`` so the patch is
+applied before any Connection is instantiated by kombu or application
+code. Remove this module and its import after celery is upgraded to a
+version that allows ``redis-py >= 6.0.0`` transitively (celery >= 5.6,
+kombu >= 5.6).
+
+References:
+
+- redis-py PR #3557: https://github.com/redis/redis-py/pull/3557
+- redis-py issue #3745: https://github.com/redis/redis-py/issues/3745
+- Linear GMLP-9206 (Redis-broker RecursionError crash, 261 restarts).
+"""
+
+from __future__ import annotations
+
+
+def _apply_redis_py_recursion_workaround() -> None:
+    """Patch ``redis.connection.Connection.send_packed_command`` in place.
+
+    Idempotent and safe to call multiple times. No-op when redis-py is
+    not importable or already contains the upstream fix.
+    """
+    try:
+        import redis.connection as _rc
+    except ImportError:
+        return
+
+    # Upstream PR #3557 introduces ``connect_check_health`` as a sibling
+    # of ``connect``. Its presence is a reliable signal that the fix is
+    # already in the running redis-py and our patch is unnecessary.
+    if hasattr(_rc.Connection, 'connect_check_health'):
+        return
+
+    # Avoid double-patching if this module is re-imported.
+    if getattr(_rc.Connection.send_packed_command, '_gumloop_patched', False):
+        return
+
+    _orig_send_packed_command = _rc.Connection.send_packed_command
+
+    def send_packed_command(self, command, check_health=True):
+        if not self._sock:
+            raise _rc.ConnectionError(
+                "Connection lost; send_packed_command will not auto-reconnect "
+                "to avoid the redis-py < 6.0.0b2 on_connect recursion "
+                "(see redis/redis-py#3557)."
+            )
+        return _orig_send_packed_command(
+            self, command, check_health=check_health,
+        )
+
+    send_packed_command._gumloop_patched = True  # type: ignore[attr-defined]
+    _rc.Connection.send_packed_command = send_packed_command
+
+
+_apply_redis_py_recursion_workaround()

--- a/celery/_redis_py_recursion_workaround.py
+++ b/celery/_redis_py_recursion_workaround.py
@@ -1,88 +1,279 @@
 """Backport of redis-py PR #3557 for redis-py < 6.0.0b2.
 
-When the broker connection drops mid-handshake (e.g. broker pod restart,
-TCP RST), redis-py < 6.0.0b2 enters infinite recursion through:
+Faithful port of the upstream fix
+(https://github.com/redis/redis-py/pull/3557). Introduces
+``connect_check_health`` and ``on_connect_check_health`` on
+``redis.connection.Connection`` and threads ``check_health`` through every
+``send_command`` call inside ``on_connect_check_health``, so the inner
+reconnect path triggered from ``check_health`` cannot re-trigger
+``check_health`` recursively.
 
-    on_connect() -> send_command("CLIENT","SETINFO",...)
+The bug
+-------
+On 2026-06-25, ~261 Celery workers crashed in production with::
+
+    CRITICAL Unrecoverable error: RecursionError(
+        'maximum recursion depth exceeded while calling a Python object')
+
+during a Redis broker rolling replacement. Cause:
+
+    connect() -> on_connect()
+      -> send_command("CLIENT","SETINFO","LIB-NAME", lib_name)
       -> send_packed_command(check_health=True)
-        -> check_health() -> _send_ping()
-          -> send_command("PING", check_health=False)
-            -> send_packed_command(check_health=False)
-              -> if not self._sock: self.connect()
-                -> on_connect() ...  (RecursionError at ~1000 frames)
+      -> check_health() -> _send_ping() -> send_command("PING", check_health=False)
+      -> send_packed_command(check_health=False)
+      -> if not self._sock: self.connect()           # <-- re-enters top
+      ... (~1000 frames until Python stack limit kills the worker)
 
-The fix in redis-py PR #3557 (released in v6.0.0b2, April 2025) splits
-``connect`` and ``on_connect`` into ``connect_check_health`` /
-``on_connect_check_health`` and threads ``check_health=False`` through
-the inner reconnect path so the cycle cannot form.
+Why a monkeypatch (instead of a redis-py upgrade)
+-------------------------------------------------
+``kombu 5.5.x`` pins ``redis<=5.2.1``; ``celery 5.5.x`` pins
+``kombu<5.6``. Adopting redis-py >= 6.0 (where the fix shipped) requires a
+coordinated ``celery 5.6+ / kombu 5.6+ / redis-py 6.0+`` upgrade plus a
+rebase of this fork onto upstream celery 5.6+. Until that lands, this
+module is the tactical patch.
 
-Because kombu < 5.6.0 pins ``redis<=5.2.1``, gumloop-celery users cannot
-adopt the fix without a coordinated celery + kombu + redis-py upgrade.
-Until that upgrade lands, this module applies the minimal localized
-patch needed to break the recursion at the call site.
+Differences from upstream
+-------------------------
+1. Applied as a monkeypatch via import side-effect from
+   ``celery/__init__.py``; the upstream fix is a redis-py code change.
+2. Logs a single WARNING per worker process the first time the
+   suppressed-check_health reconnect actually fires. Upstream is silent.
+   This restores a small observability signal: when a transient broker
+   blip is silently recovered, the worker log line tells operators it
+   happened. Subsequent reconnects log at DEBUG to avoid spam.
 
-The patch:
+The patch is a no-op when:
+  - ``redis-py`` is not installed;
+  - ``redis-py >= 6.0.0b2`` (detected via ``Connection.connect_check_health``).
 
-- replaces ``Connection.send_packed_command``'s "no socket -> connect()"
-  branch with a clean ``ConnectionError``. Higher-level callers
-  (kombu's Channel, redis.client.Redis, application pools) already
-  handle ``ConnectionError`` with their own retry/reconnect logic, so
-  this surfaces the failure cleanly instead of recursing.
-
-The patch is a no-op when redis-py is unavailable or when it already
-contains the upstream fix (detected by ``connect_check_health`` method).
-
-This module is imported from ``celery/__init__.py`` so the patch is
-applied before any Connection is instantiated by kombu or application
-code. Remove this module and its import after celery is upgraded to a
-version that allows ``redis-py >= 6.0.0`` transitively (celery >= 5.6,
-kombu >= 5.6).
-
-References:
-
+References
+----------
 - redis-py PR #3557: https://github.com/redis/redis-py/pull/3557
 - redis-py issue #3745: https://github.com/redis/redis-py/issues/3745
-- Linear GMLP-9206 (Redis-broker RecursionError crash, 261 restarts).
+- Linear GMLP-9206
 """
 
 from __future__ import annotations
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def _apply_redis_py_recursion_workaround() -> None:
-    """Patch ``redis.connection.Connection.send_packed_command`` in place.
-
-    Idempotent and safe to call multiple times. No-op when redis-py is
-    not importable or already contains the upstream fix.
-    """
+    """Patch ``redis.connection.Connection`` in place. Idempotent."""
     try:
         import redis.connection as _rc
     except ImportError:
         return
 
-    # Upstream PR #3557 introduces ``connect_check_health`` as a sibling
-    # of ``connect``. Its presence is a reliable signal that the fix is
-    # already in the running redis-py and our patch is unnecessary.
-    if hasattr(_rc.Connection, 'connect_check_health'):
+    # Upstream fix already present (redis-py >= 6.0.0b2). Nothing to do.
+    if hasattr(_rc.Connection, "connect_check_health"):
         return
 
-    # Avoid double-patching if this module is re-imported.
-    if getattr(_rc.Connection.send_packed_command, '_gumloop_patched', False):
+    # Don't double-patch on re-import.
+    if getattr(_rc.Connection.send_packed_command, "_gumloop_patched", False):
         return
+
+    import socket
+
+    from redis._parsers import _RESP2Parser, _RESP3Parser
+    from redis.credentials import UsernamePasswordCredentialProvider
+    from redis.exceptions import (
+        AuthenticationError,
+        AuthenticationWrongNumberOfArgsError,
+        ConnectionError,
+        RedisError,
+        ResponseError,
+        TimeoutError,
+    )
+    from redis.utils import str_if_bytes
+
+    # One-shot flag so we WARN once per worker process, then DEBUG.
+    _warned_once = [False]
+
+    def on_connect_check_health(self, check_health: bool = True) -> None:
+        """Initialize the connection, authenticate and select a database.
+
+        Verbatim copy of redis-py 5.2.1's ``Connection.on_connect``,
+        modified to thread ``check_health`` through every ``send_command``
+        call so the inner reconnect path can suppress ``check_health`` and
+        break the recursion.
+        """
+        self._parser.on_connect(self)
+        parser = self._parser
+
+        auth_args = None
+        if self.credential_provider or (self.username or self.password):
+            cred_provider = (
+                self.credential_provider
+                or UsernamePasswordCredentialProvider(self.username, self.password)
+            )
+            auth_args = cred_provider.get_credentials()
+
+        if auth_args and self.protocol not in [2, "2"]:
+            if isinstance(self._parser, _RESP2Parser):
+                self.set_parser(_RESP3Parser)
+                self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
+                self._parser.on_connect(self)
+            if len(auth_args) == 1:
+                auth_args = ["default", auth_args[0]]
+            self.send_command(
+                "HELLO",
+                self.protocol,
+                "AUTH",
+                *auth_args,
+                check_health=check_health,
+            )
+            self.handshake_metadata = self.read_response()
+        elif auth_args:
+            # AUTH itself must not check health (the connection isn't
+            # authenticated yet, so PING would fail). Preserved from upstream.
+            self.send_command("AUTH", *auth_args, check_health=False)
+            try:
+                auth_response = self.read_response()
+            except AuthenticationWrongNumberOfArgsError:
+                self.send_command("AUTH", auth_args[-1], check_health=False)
+                auth_response = self.read_response()
+            if str_if_bytes(auth_response) != "OK":
+                raise AuthenticationError("Invalid Username or Password")
+        elif self.protocol not in [2, "2"]:
+            if isinstance(self._parser, _RESP2Parser):
+                self.set_parser(_RESP3Parser)
+                self._parser.EXCEPTION_CLASSES = parser.EXCEPTION_CLASSES
+                self._parser.on_connect(self)
+            self.send_command("HELLO", self.protocol, check_health=check_health)
+            self.handshake_metadata = self.read_response()
+            if (
+                self.handshake_metadata.get(b"proto") != self.protocol
+                and self.handshake_metadata.get("proto") != self.protocol
+            ):
+                raise ConnectionError("Invalid RESP version")
+
+        if self.client_name:
+            self.send_command(
+                "CLIENT", "SETNAME", self.client_name, check_health=check_health,
+            )
+            if str_if_bytes(self.read_response()) != "OK":
+                raise ConnectionError("Error setting client name")
+
+        try:
+            if self.lib_name:
+                self.send_command(
+                    "CLIENT",
+                    "SETINFO",
+                    "LIB-NAME",
+                    self.lib_name,
+                    check_health=check_health,
+                )
+                self.read_response()
+        except ResponseError:
+            pass
+
+        try:
+            if self.lib_version:
+                self.send_command(
+                    "CLIENT",
+                    "SETINFO",
+                    "LIB-VER",
+                    self.lib_version,
+                    check_health=check_health,
+                )
+                self.read_response()
+        except ResponseError:
+            pass
+
+        if self.db:
+            self.send_command("SELECT", self.db, check_health=check_health)
+            if str_if_bytes(self.read_response()) != "OK":
+                raise ConnectionError("Invalid Database")
+
+    def connect_check_health(self, check_health: bool = True) -> None:
+        """Connect to the Redis server if not already connected.
+
+        Verbatim copy of redis-py 5.2.1's ``Connection.connect``, modified
+        to call ``on_connect_check_health(check_health=check_health)``
+        instead of ``on_connect()``.
+        """
+        if self._sock:
+            return
+        try:
+            sock = self.retry.call_with_retry(
+                lambda: self._connect(),
+                lambda error: self.disconnect(error),
+            )
+        except socket.timeout:
+            raise TimeoutError("Timeout connecting to server")
+        except OSError as e:
+            raise ConnectionError(self._error_message(e))
+
+        self._sock = sock
+        try:
+            if self.redis_connect_func is None:
+                self.on_connect_check_health(check_health=check_health)
+            else:
+                self.redis_connect_func(self)
+        except RedisError:
+            self.disconnect()
+            raise
+
+        # Run any user callbacks. The only internal callback today is
+        # pubsub channel/pattern resubscription.
+        self._connect_callbacks = [ref for ref in self._connect_callbacks if ref()]
+        for ref in self._connect_callbacks:
+            callback = ref()
+            if callback:
+                callback(self)
+
+    def connect(self) -> None:
+        """Backwards-compatible wrapper. Same shape as upstream PR #3557."""
+        self.connect_check_health(check_health=True)
+
+    def on_connect(self) -> None:
+        """Backwards-compatible wrapper. Same shape as upstream PR #3557."""
+        self.on_connect_check_health(check_health=True)
 
     _orig_send_packed_command = _rc.Connection.send_packed_command
 
-    def send_packed_command(self, command, check_health=True):
+    def send_packed_command(self, command, check_health: bool = True):
+        """Same as the original ``send_packed_command``, but when reconnect
+        is needed mid-command, suppress ``check_health`` during the inner
+        reconnect to break the redis-py < 6.0.0b2 recursion.
+
+        Also logs the reconnect for operator visibility (once per process
+        at WARNING, then DEBUG).
+        """
         if not self._sock:
-            raise _rc.ConnectionError(
-                "Connection lost; send_packed_command will not auto-reconnect "
-                "to avoid the redis-py < 6.0.0b2 on_connect recursion "
-                "(see redis/redis-py#3557)."
-            )
-        return _orig_send_packed_command(
-            self, command, check_health=check_health,
-        )
+            if not _warned_once[0]:
+                _warned_once[0] = True
+                logger.warning(
+                    "[GMLP-9206] redis-py reconnect mid-command "
+                    "(host=%s port=%s db=%s). Backport of redis-py PR #3557 "
+                    "active; transient broker blip silently recovered. "
+                    "This WARNING is emitted once per worker process; "
+                    "subsequent reconnects log at DEBUG.",
+                    getattr(self, "host", "?"),
+                    getattr(self, "port", "?"),
+                    getattr(self, "db", "?"),
+                )
+            else:
+                logger.debug(
+                    "[GMLP-9206] redis-py reconnect mid-command "
+                    "(host=%s port=%s db=%s)",
+                    getattr(self, "host", "?"),
+                    getattr(self, "port", "?"),
+                    getattr(self, "db", "?"),
+                )
+            self.connect_check_health(check_health=False)
+        return _orig_send_packed_command(self, command, check_health=check_health)
 
     send_packed_command._gumloop_patched = True  # type: ignore[attr-defined]
+
+    _rc.Connection.connect_check_health = connect_check_health
+    _rc.Connection.on_connect_check_health = on_connect_check_health
+    _rc.Connection.connect = connect
+    _rc.Connection.on_connect = on_connect
     _rc.Connection.send_packed_command = send_packed_command
 
 


### PR DESCRIPTION
## What

Adds `celery/_redis_py_recursion_workaround.py`, imported from `celery/__init__.py`, that backports [redis-py PR #3557](https://github.com/redis/redis-py/pull/3557) for `redis-py < 6.0.0b2`. Faithful port of the upstream fix:

- Adds `Connection.connect_check_health` and `Connection.on_connect_check_health`.
- Threads `check_health` through every `send_command` in the `on_connect` chain.
- Changes `send_packed_command`'s stale-socket reconnect from `self.connect()` to `self.connect_check_health(check_health=False)`.
- Preserves the upstream transparent-reconnect contract.
- Adds a single WARNING-per-process observability log the first time the suppressed-check_health reconnect fires (subsequent reconnects log at DEBUG).

## Why

On 2026-06-26T03:46:35Z–03:46:50Z, **171 Celery worker pods** in production crashed with `RecursionError('maximum recursion depth exceeded while calling a Python object')` during a Redis Deployment `Recreate` rollout. Confirmed via prod cluster inspection: Redis ReplicaSet `redis-6f9c8ffc9f` was created at `2026-06-26T03:45:56Z`, matching the first worker "Connection to broker lost" log at 03:45:55.820Z.

The bug is in `redis-py 5.2.1`'s reconnect path (upstream [issue #3745](https://github.com/redis/redis-py/issues/3745), fixed in [PR #3557](https://github.com/redis/redis-py/pull/3557)):

```text
connect() -> on_connect()
  -> send_command("CLIENT","SETINFO","LIB-NAME", lib_name)
  -> send_packed_command(check_health=True)
    -> check_health() -> retry.call_with_retry(_send_ping, _ping_failed)
      -> _send_ping()                             # fails (any retryable error)
      -> _ping_failed() -> disconnect()           # _sock = None
      -> _send_ping()                             # retry
        -> send_command("PING", check_health=False)
        -> send_packed_command(check_health=False)
        -> if not self._sock: self.connect()      # <-- re-enters top of chain
        -> on_connect() -> CLIENT SETINFO -> check_health -> ...
        -> recursion (~166 levels until Python stack limit)
```

Trigger conditions (all set in every Celery service's `broker_transport_options`):

- `health_check_interval = 30`
- `retry_on_timeout = True`
- `lib_name` non-empty (redis-py defaults it to `"redis-py"`)

**Failure-mode agnostic**: the recursion fires regardless of whether the initial `_send_ping` failure is `TimeoutError`, `ConnectionError`, `BusyLoadingError`, or a raw socket error. This fix breaks the cycle at the reconnect point, so all these variants surface as normal handleable errors.

## Why not just upgrade redis-py

`kombu==5.5.2` pins `redis<=5.2.1`. `celery 5.5.x` pins `kombu<5.6`. A redis-py bump alone is rejected by `uv sync`. Proper fix is a coordinated `celery 5.6+ / kombu 5.6+ / redis-py 6.0+` upgrade, which also requires rebasing this fork onto upstream celery 5.6+ (forward-porting rbehal's spawn pool work, PR #1 `--disable-prefetch`, PR #2 GMLP-9012). That is tracked strategically. This PR is the tactical mitigation.

## Idempotency / no-op conditions

- redis-py not installed → no-op
- redis-py ≥ 6.0.0b2 (detected via `hasattr(Connection, 'connect_check_health')`) → no-op
- Guards against double-patching on re-import

## Validation

Two reproduction methods worked on the beta cluster:

- **Deterministic in-pod repro**: `kubectl exec` a Python script into a worker pod that monkeypatches `redis.connection.Connection._send_ping` to always raise `TimeoutError` after sending PING. Then `client.ping()` against live beta Redis. Unpatched → 5/5 `RecursionError`. Patched → 5/5 non-recursion.
- **Live Redis `DEBUG SLEEP` + tracer script**: temporarily enabled `--enable-debug-command yes` on the beta Redis Deployment, then `redis-cli DEBUG SLEEP 180` (backgrounded) + a tracer script inside a worker pod using `socket_timeout=0.2` so each recursion level ≈ 200 ms. Unpatched → `RecursionError max_depth=996` in 13.42 s. Patched → non-recursion `TimeoutError` at `max_depth=29` in 0.81 s. Redis deployment reverted after.

| Test | Image | Result |
|---|---|---|
| Synthetic in-pod, unpatched | `5.5.3+gumloop.0.1.5` | 5/5 `RecursionError` |
| Synthetic in-pod, patched (inline) | unfixed + inline monkeypatch | 5/5 non-recursion |
| Synthetic in-pod, patched (via wheel) | `5.5.3+gumloop.0.1.5.gmlp9206.test1` | 5/5 non-recursion, WARNING log fires |
| Live Redis, unpatched (tracer, `DEBUG SLEEP 180` + `socket_timeout=0.2`) | unfixed | `RecursionError` at `max_depth=996` in 13.42s |
| Live Redis, patched (tracer, same setup) | fixed | non-recursion `TimeoutError` at `max_depth=29` in 0.81s |
| Prod incident (2026-06-26) | unfixed | 171 RecursionError crashes in 15s window |

Attempts that did NOT naturally reproduce on beta (documenting so we don't retry them):

- `kubectl scale deployment redis --replicas=0 → 1`: beta Redis warms up in <1s; race window too narrow for the ~5-8 beta workers to land in.
- `kubectl rollout restart deployment/redis` (`strategy: Recreate`), even with worker deployments scaled to 24: same as above; 20 workers logged "Connection to broker lost" but none crashed.
- `redis-cli CLIENT PAUSE 30000 ALL`: Redis eventually returns responses when the pause ends; no timeout fires; no `_ping_failed → retry with _sock=None` cycle enters.
- `kubectl exec redis -- kill -STOP 1` for 45s: TCP keepalive on the worker is 60+10×6 ≈ 120s, longer than the SIGSTOP window, so idle worker sockets never notice the stall.
- `DEBUG SLEEP 180` + rollout restart a real celery worker pod on the unfixed image: worker's actual broker `socket_timeout=10`, so each recursion level takes ~10s; only ~15–18 levels accumulated in 3 minutes vs the ~166 needed for Python's default 1000-frame limit. Would require ≈28 minutes of stall to reproduce naturally on beta.

Test wheel `5.5.3+gumloop.0.1.5.gmlp9206.test1` is on beta cluster now. **Do not promote that tag to staging/prod.** Cut a clean `5.5.3+gumloop.0.1.6` on merge.

## Caveats

- Only takes effect when `celery` is imported (`celery/__init__.py` applies the patch as import side-effect). For our Celery broker code paths this is universally true.
- App code that uses redis-py directly without importing celery first will NOT get the workaround; that path is covered by the coordinated redis-py upgrade tracked separately.

## References

- redis-py PR #3557: https://github.com/redis/redis-py/pull/3557
- redis-py issue #3745: https://github.com/redis/redis-py/issues/3745
- redis-py issue #2563 (same recursion via `max clients reached`): https://github.com/redis/redis-py/issues/2563
- Linear: [GMLP-9206](https://linear.app/gumloop/issue/GMLP-9206/redis-broker-recursionerror-crash-261-restarts)

